### PR TITLE
Python 3.4+ compatibility fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,10 @@ setup(name="zang",
           'Topic :: Utilities'],
       description=('This Python pacakge is an open source tool built to '
                    'simplify interaction with the Zang telephony platform.'),
-      install_requires=['enum', 'requests', 'python-dateutil'],
+      install_requires=['requests', 'python-dateutil'],
+      extras_require={
+          ":python_version<'3.4'": ['enum'],
+      },
       keywords='zang api wrapper',
       license='MIT License',
       packages=find_packages(exclude=['tests', 'tests.*', 'docs']),


### PR DESCRIPTION
For python versions 3.4+, don't install the enums package. This enables the package to be used on more recent versions of Python, otherwise pip install will fail with an error.